### PR TITLE
Updated redirection code, simplesaml library path setting and baseurls

### DIFF
--- a/private/simplesamlphp-1.14.14/config/config.php
+++ b/private/simplesamlphp-1.14.14/config/config.php
@@ -9,50 +9,25 @@ if (!ini_get('session.save_handler')) {
     ini_set('session.save_handler', 'file');
 }
 
+$CanonicalHost = $_SERVER[HTTP_HOST];
 if ((isset($_ENV)) && (isset($_ENV['PANTHEON_ENVIRONMENT']))) {
 	$ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
 	$drop_id = $ps['conf']['pantheon_binding'];
 	$db = $ps['databases']['default']['default'];
-    $certdir = '/srv/bindings/'. $drop_id .'/code/web/private/saml-cert/';
+	$certdir = '/srv/bindings/'. $drop_id .'/code/web/private/saml-cert/';
 	$tempdir = '/srv/bindings/'. $drop_id .'/tmp/simplesaml';
 	/* You have to include redirects-functions here because settings.php hasn't been included by the
 	 * time this file is included into drupal. 
  	 */
-	$CanonicalHost = $_SERVER[HTTP_HOST];
 	if (file_exists($_SERVER['DOCUMENT_ROOT']. '/sites/default/settings.redirects-functions.php')) {
 		require_once($_SERVER['DOCUMENT_ROOT']. '/sites/default/settings.redirects-functions.php');
 		$CanonicalHost = getCanonicalHost();
 	}
 } else {
-    $certdir = 'cert/';
+	$certdir = 'cert/';
 	$tempdir = '/tmp/simplesaml';
 	$db = $databases['default']['default'];
 }
-
-
-/*
- ["HTTP_X_FORWARDED_SERVER"]=>
-  string(56) "www.sas.upenn.edu, cache-jfk8141-JFK, cache-mdw17327-MDW"
-  ["HTTP_X_FORWARDED_PROTO"]=>
-  string(5) "https"
-  ["HTTP_X_FORWARDED_HOST"]=>
-  string(51) "www.sas.upenn.edu, test2-sas-school.pantheonsite.io"
-  ["HTTP_X_FORWARDED_FOR"]=>
-  string(45) "158.130.227.242, 128.91.219.93, 128.91.219.93"
-  ["HTTP_X_FASTLY_ORIG_HOST"]=>
-  string(51) "www.sas.upenn.edu, test2-sas-school.pantheonsite.io"
-  ["HTTP_X_BYPASS_CACHE"]=>
-  string(1) "1"
-  ["HTTP_USER_AGENT_HTTPS"]=>
-  string(2) "ON"
-  ["HTTP_UPGRADE_INSECURE_REQUESTS"]=>
-  string(1) "1"
-  ["HTTP_SURROGATE_CAPABILITY"]=>
-  string(14) "styx="ESI/1.0""
-  ["HTTP_REFERER"]=>
-  string(39) "https://www.sas.upenn.edu/admin/reports"
-  ["HTTP_PANTHEON_PROTO_CHECKS"]=>
-*/
 
 $config = array(
 

--- a/sites/default/default.settings.php
+++ b/sites/default/default.settings.php
@@ -643,6 +643,6 @@ $conf['404_fast_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
  */
 /* Every site will need its own primaryredirect settings file  */
 if (file_exists(__DIR__ . '/settings.redirects-allsites.php')) {
-    include __DIR__ . "/settings.redirects-allsites.php";
+   require_once(__DIR__ . '/settings.redirects-allsites.php');
 }
 

--- a/sites/default/default.settings.redirects-site.php
+++ b/sites/default/default.settings.redirects-site.php
@@ -1,11 +1,14 @@
 <?php
 // Site specific custom redirects
 
+//global $primary_domain;
 //$primary_domain = 'www.UPDATEME.upenn.edu';
 
 // RewriteMap example
 /*
- * $RewriteMap = array('@^/foo/bar.htm$@'        => '/node/1',
+ * global $RewriteMap;
+ * $RewriteMap = array(
+ * 		       '@^/foo/bar.htm$@'        => '/node/1',
  *                     '@^/foo/index.html$@'     => '/node/1',
  *                    );
  */

--- a/sites/default/default.settings.redirects-site.php
+++ b/sites/default/default.settings.redirects-site.php
@@ -4,6 +4,9 @@
 //global $primary_domain;
 //$primary_domain = 'www.UPDATEME.upenn.edu';
 
+//global $drupal_hash_salt;
+//$drupal_hash_salt = 'abc';
+
 // RewriteMap example
 /*
  * global $RewriteMap;

--- a/sites/default/settings.redirects-functions.php
+++ b/sites/default/settings.redirects-functions.php
@@ -1,0 +1,74 @@
+<?php
+
+if (file_exists(__DIR__ . '/settings.redirects-site.php')) {
+    include __DIR__ . "/settings.redirects-site.php";
+}
+
+
+function isPantheonSite () {
+	return(preg_match('@pantheonsite.io@',$_SERVER['HTTP_HOST']));
+}
+
+function isD7() {
+	return(file_exists($_SERVER['DOCUMENT_ROOT']. '/sites/all/modules'));
+}
+
+function isD8() {
+	return(isset($_ENV['HOME']) && (file_exists($_ENV['HOME'].'/web') || file_exists($_SERVER['DOCUMENT_ROOT'].'/modules/contrib')));
+}
+
+function isProxied() {
+	// HTTP_X_FORWARDED_HOST is undefined when coming in through the load-balancer
+	// HTTP_HOST == HTTP_X_FORWARDED_HOST for direct access to pantheon + via CDN
+	// via proxy, HTTP_HOST -> 'live-sas-school.pantheonsite.io' while
+	//   HTTP_X_FORWARDED_HOST -> 'www.sas.upenn.edu, live-sas-school.pantheonsite.io'
+	return(	   isset($_SERVER['HTTP_X_FORWARDED_HOST']) 
+        	&& ($_SERVER['HTTP_HOST'] != $_SERVER['HTTP_X_FORWARDED_HOST']));
+}
+
+
+function getCanonicalHost() {
+	global $primary_domain;
+
+	$CanonicalHost = $_SERVER['HTTP_HOST'];
+	if (isset($primary_domain)) {
+		if (!isPantheonSite() || isProxied()) {
+			// CDN or load balancer if not a pantheonsite
+			// or else we are a pantheonsite and need to check if we're proxied
+			$CanonicalHost = $primary_domain;
+		}
+	}
+
+	return($CanonicalHost);
+}
+
+function getClientHost() {
+	if (   isset($_SERVER['HTTP_X_FORWARDED_HOST'])
+	    && preg_match('@^(.*?)(,|$)@',$_SERVER['HTTP_X_FORWARDED_HOST'],$match)
+	    && (count($match) > 1)) {
+		return($match[1]);
+	}
+	else {
+		return($_SERVER['HTTP_HOST']);
+	}
+}
+
+
+function redirectTo($url) {
+	if (extension_loaded('newrelic')) {
+		newrelic_name_transaction("redirect");
+	}
+            
+	header('HTTP/1.0 301 Moved Permanently');
+	header('Location: '. $url);
+	exit();
+}
+
+function isHTTP() {
+    // From https://pantheon.io/docs/domains/ 
+    return (   !isset($_SERVER['HTTP_USER_AGENT_HTTPS']) 
+            || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON'
+            || empty($_SERVER['HTTPS']) 
+            || $_SERVER['HTTPS'] == "OFF");
+} 
+


### PR DESCRIPTION
config.php now uses the redirection functions to set the CanoncialHost and the config->baseurlpath
using require_once instead of include to settings.redirect-allsites.php.

default.settings.php now does a require once on settings.redirect-allsites.php instead
of an include.

settings.redirects-functions.php includes a set of useful functions for determining
details about how the site is being accessed and whether the site is d7 or d8.

settings.redirect-allsites.php now does a require_once of settings.redirects-functions.php
and uses the functions to set canoncial hosts and determine if redirects are needed as
well as setting the simplesaml library path.

default.settings.redirects-site.php has been changed to add global declarations to the
$pimary_domain and $RewriteMap varibles.

This code has been tested on elp(d7) and sas-school.test2 (d8-refactored)